### PR TITLE
Bugfix/delicten verwijderen knop

### DIFF
--- a/WijkAgent.Core/Services/CrimeService.cs
+++ b/WijkAgent.Core/Services/CrimeService.cs
@@ -100,6 +100,22 @@ namespace WijkAgent.Core.Services
         }
 
         /// <summary>
+        /// Nieuw: verwijdert een bestaand delict op basis van ID.
+        /// </summary>
+        /// <param name="id">Het ID van het delict dat verwijderd moet worden.</param>
+        /// <returns>True als verwijderen gelukt is, anders false.</returns>
+        public async Task<bool> DeleteAsync(int id)
+        {
+            var existing = await _db.Crimes.FirstOrDefaultAsync(c => c.Id == id);
+            if (existing is null)
+                return false;
+
+            _db.Crimes.Remove(existing);
+            await _db.SaveChangesAsync();
+            return true;
+        }
+
+        /// <summary>
         /// Haalt delicten op die voldoen aan de opgegeven filtercriteria.
         /// Mogelijke filters:
         /// - Datum vanaf (from)

--- a/WijkAgent.Core/Services/ICrimeService.cs
+++ b/WijkAgent.Core/Services/ICrimeService.cs
@@ -53,13 +53,20 @@ namespace WijkAgent.Core.Services
         Task<Crime?> UpdateAsync(Crime crime);
 
         /// <summary>
+        /// Nieuw: verwijdert een bestaand delict op basis van ID.
+        /// </summary>
+        /// <param name="id">Het ID van het delict dat verwijderd moet worden.</param>
+        /// <returns>True als verwijderen gelukt is, anders false.</returns>
+        Task<bool> DeleteAsync(int id);
+
+        /// <summary>
         /// Haalt een lijst delicten op die voldoen aan de opgegeven filtercriteria.
         /// Alle filterparameters zijn optioneel.
         /// </summary>
         /// <param name="from">Optioneel: filter vanaf deze datum/tijd.</param>
         /// <param name="to">Optioneel: filter tot en met deze datum/tijd.</param>
         /// <param name="type">Optioneel: type delict waarop gefilterd wordt.</param>
-        /// <param name="city">Optioneel: stad waarop gefilterd wordt.</param>
+        /// <param name="city">Optioneel: stad waarop wordt gefilterd.</param>
         /// <returns>Lijst delicten die voldoen aan de filterinstellingen.</returns>
         Task<List<Crime>> GetFilteredAsync(
             DateTime? from,

--- a/wijkagent/Components/Pages/Home.razor
+++ b/wijkagent/Components/Pages/Home.razor
@@ -167,11 +167,18 @@
                             </p>
                         </div>
 
-                        <!-- Start bewerken van dit delict -->
-                        <button class="delict-edit-btn"
-                                @onclick="async () => await StartEditCrime(selectedCrime.Id)">
-                            Bewerken
-                        </button>
+                        <!-- Acties voor geselecteerd delict -->
+                        <div style="display:flex; gap:10px; align-items:center;">
+                            <button class="delict-edit-btn"
+                                    @onclick="async () => await StartEditCrime(selectedCrime.Id)">
+                                Bewerken
+                            </button>
+
+                            <button class="btn btn-danger"
+                                    @onclick="DeleteSelectedCrime">
+                                Verwijderen
+                            </button>
+                        </div>
                     </div>
                 }
             </div>
@@ -309,7 +316,12 @@
     {
         allCrimes = await CrimeService.GetAllAsync();
 
-        if (selectedCrime is null && allCrimes is { Count: > 0 })
+        // Nieuw: als het geselecteerde delict verwijderd is, of null is, pak dan automatisch de nieuwste
+        if (allCrimes is null || allCrimes.Count == 0)
+        {
+            selectedCrime = null;
+        }
+        else if (selectedCrime is null || !allCrimes.Any(c => c.Id == selectedCrime.Id))
         {
             selectedCrime = allCrimes.First();
         }
@@ -523,6 +535,46 @@
 
         ResetForm();
         await LoadCrimes();
+    }
+
+    /// <summary>
+    /// Nieuw: Verwijdert het geselecteerde delict (na bevestiging) en refresht kaart + lijst.
+    /// </summary>
+    private async Task DeleteSelectedCrime()
+    {
+        if (selectedCrime is null)
+            return;
+
+        // Passende comment: extra safety zodat je niet per ongeluk data weggooit
+        var confirm = await JS.InvokeAsync<bool>("confirm",
+            $"Weet je zeker dat je delict #{selectedCrime.Id} wilt verwijderen?");
+
+        if (!confirm)
+            return;
+
+        var id = selectedCrime.Id;
+
+        // Als je nu dit delict aan het bewerken was: stop bewerken
+        if (isEditing && editingCrimeId == id)
+        {
+            isEditing = false;
+            editingCrimeId = null;
+            ResetForm();
+        }
+
+        var deleted = await CrimeService.DeleteAsync(id);
+
+        if (!deleted)
+        {
+            await JS.InvokeVoidAsync("alert", "Verwijderen is mislukt. Delict bestaat mogelijk niet meer.");
+            return;
+        }
+
+        // Zet selectie leeg; LoadCrimes kiest daarna automatisch de nieuwste (of null)
+        selectedCrime = null;
+
+        await LoadCrimes();
+        StateHasChanged();
     }
 
     /// <summary>


### PR DESCRIPTION
## Bugfix: delict verwijderen via overzicht

In deze wijziging is het mogelijk gemaakt om een **geselecteerd delict te verwijderen** vanuit de homepagina.

### Wat is aangepast?
- Toevoegen van een **verwijderknop** bij het geselecteerde delict
- Het juiste delict wordt verwijderd op basis van de selectie (marker / overzicht)
- Na verwijderen wordt de kaart en het overzicht automatisch bijgewerkt

### Waarom?
Voorheen kon een delict alleen bekeken of bewerkt worden.  
Met deze aanpassing kan een wijkagent ook **foutieve of verouderde delicten verwijderen**, wat de flexibiliteit en correctheid van het systeem verbetert.
